### PR TITLE
chore: Setup GitHub Actions with Docker for CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,45 +5,88 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # APIコスト削減のため定期実行は一時的に無効化
+  # schedule:
+  #   - cron: '0 0 * * *'  # 毎日深夜に実行
+
+env:
+  DOCKER_IMAGE: langgraph-agentic-system-test
+  PYTHONPATH: /app
+  PYTHONIOENCODING: utf-8
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+  SPOTIFY_USER_ID: ${{ secrets.SPOTIFY_USER_ID }}
+  SPOTIFY_TOKEN: ${{ secrets.SPOTIFY_TOKEN }}
 
 jobs:
   test:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Build Docker image
+      uses: docker/build-push-action@v5
       with:
-        python-version: '3.10'
-        
-    - name: Install dependencies
+        context: .
+        load: true
+        tags: ${{ env.DOCKER_IMAGE }}:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    
+    - name: Run MCP Server Tests
       run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        docker run --rm \
+          -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
+          -e TAVILY_API_KEY=${{ secrets.TAVILY_API_KEY }} \
+          -e SPOTIFY_USER_ID=${{ secrets.SPOTIFY_USER_ID }} \
+          -e SPOTIFY_TOKEN=${{ secrets.SPOTIFY_TOKEN }} \
+          ${{ env.DOCKER_IMAGE }}:latest tests/test_mcp_server_spotify.py tests/test_mcp_server_search.py tests/test_mcp_server_time.py
         
-    - name: Run tests
+    - name: Run Planner Agent Tests
       run: |
-        # テストコマンドをここに追加
-        echo "Running tests..."
+        docker run --rm \
+          -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
+          -e TAVILY_API_KEY=${{ secrets.TAVILY_API_KEY }} \
+          -e SPOTIFY_USER_ID=${{ secrets.SPOTIFY_USER_ID }} \
+          -e SPOTIFY_TOKEN=${{ secrets.SPOTIFY_TOKEN }} \
+          ${{ env.DOCKER_IMAGE }}:latest tests/test_planner_agent.py
+        
+    - name: Run Integration Tests
+      run: |
+        docker run --rm \
+          -e OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
+          -e TAVILY_API_KEY=${{ secrets.TAVILY_API_KEY }} \
+          -e SPOTIFY_USER_ID=${{ secrets.SPOTIFY_USER_ID }} \
+          -e SPOTIFY_TOKEN=${{ secrets.SPOTIFY_TOKEN }} \
+          ${{ env.DOCKER_IMAGE }}:latest tests/test_integration.py
+        
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         
   build:
     needs: test
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Build Docker image
+      uses: docker/build-push-action@v5
       with:
-        python-version: '3.10'
-        
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        context: .
+        load: true
+        tags: ${{ env.DOCKER_IMAGE }}:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         
     - name: Build
       run: |
@@ -56,7 +99,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Deploy
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# 必要なパッケージをインストール
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir pytest pytest-asyncio httpx pytest-cov python-dotenv
+
+# ソースコードをコピー
+COPY src/ ./src/
+COPY tests/ ./tests/
+
+# 環境変数を設定
+ENV PYTHONPATH=/app
+ENV PYTHONIOENCODING=utf-8
+
+# テスト実行用のエントリーポイント
+ENTRYPOINT ["pytest"]
+CMD ["-v"] 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,42 @@
+import pytest
+import httpx
+from fastapi.testclient import TestClient
+from tools.spotify_mcp import app as spotify_app
+from tools.weather_mcp import app as weather_app
+from graphs.planner_graph import create_planner_graph
+
+spotify_client = TestClient(spotify_app)
+weather_client = TestClient(weather_app)
+
+def test_end_to_end_weekend_planning():
+    """週末プランニングのエンドツーエンドテスト"""
+    # 1. 天気情報の取得
+    weather_response = weather_client.get("/forecast", params={
+        "location": "東京",
+        "date": "2024-03-30"
+    })
+    assert weather_response.status_code == 200
+    weather_data = weather_response.json()
+    
+    # 2. スポット検索
+    spotify_response = spotify_client.post("/search", json={
+        "query": "週末 東京 おすすめ",
+        "limit": 5
+    })
+    assert spotify_response.status_code == 200
+    spotify_data = spotify_response.json()
+    
+    # 3. LangGraphによる統合
+    graph = create_planner_graph()
+    result = graph.run({
+        "task": "週末のスポットを探す",
+        "location": "東京",
+        "date": "2024-03-30",
+        "weather": weather_data,
+        "music_recommendations": spotify_data
+    })
+    
+    assert result is not None
+    assert "recommendations" in result
+    assert "weather_advice" in result
+    assert "music_suggestions" in result 

--- a/tests/test_planner_graph.py
+++ b/tests/test_planner_graph.py
@@ -1,0 +1,21 @@
+import pytest
+from langgraph.graph import Graph
+from graphs.planner_graph import create_planner_graph
+
+def test_planner_graph_creation():
+    """プランナーグラフの作成テスト"""
+    graph = create_planner_graph()
+    assert isinstance(graph, Graph)
+    assert len(graph.nodes) > 0
+
+def test_planner_graph_execution():
+    """プランナーグラフの実行テスト"""
+    graph = create_planner_graph()
+    result = graph.run({
+        "task": "週末のスポットを探す",
+        "location": "東京",
+        "date": "2024-03-30"
+    })
+    assert result is not None
+    assert "recommendations" in result
+    assert len(result["recommendations"]) > 0 

--- a/tests/test_spotify_mcp.py
+++ b/tests/test_spotify_mcp.py
@@ -1,0 +1,27 @@
+import pytest
+import httpx
+from tools.spotify_mcp import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+def test_spotify_search():
+    """Spotify検索エンドポイントのテスト"""
+    response = client.post("/search", json={
+        "query": "test song",
+        "limit": 5
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert "tracks" in data
+    assert len(data["tracks"]) <= 5
+
+def test_spotify_playback():
+    """Spotify再生エンドポイントのテスト"""
+    response = client.post("/play", json={
+        "track_id": "test_track_id"
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert "status" in data
+    assert data["status"] == "success" 


### PR DESCRIPTION
- Dockerfileを追加し、テスト環境をDocker化
- GitHub ActionsでDockerビルド＆テストを実行するワークフローを追加
- 定期実行はAPIコスト配慮のため一時的に無効化
- mainブランチへのマージやPR時のみCI/CDが動作
- 必要なAPIキーはGitHub Secretsで管理