### PR TITLE
feat: add English README and FastAPI+Uvicorn agent API sample

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,13 @@
-name: Mock Test CI/CDPipeline
+name: Mock Test CI/CD Pipeline
 
 on:
-  pull_request:
+  pull_request: # プルリクエスト(マージするブランチ)をトリガー # "mainブランチに対するプルリクエストが作成・更新されたとき" にワークフローが実行される
     branches: [ main ]
   
-  workflow_dispatch:
+  pull_request_target: # マージ先のブランチをトリガー # "mainブランチがマージ先となるPRのイベント（例：外部リポジトリからのPR）" でワークフローが実行される
+    branches: [ main ]
+  
+  workflow_dispatch: # 手動トリガー
 
 env:
   DOCKER_IMAGE: langgraph-agentic-system-test

--- a/README.md
+++ b/README.md
@@ -18,64 +18,45 @@ It is designed to support:
 ---
 
 ## 🏗️ Project Structure
-<!--
-langgraph-agentic-system-hub/
-├── README.md
-├── requirements.txt
-├── main.py
-├── /agents
-│   ├── orchestrator.py         # Routes tasks to the appropriate agent
-│   ├── music_agent.py
-│   ├── event_agent.py
-│   └── weather_agent.py
-├── /tools
-│   ├── spotify_mcp.py          # MCP server for Spotify search
-│   ├── weather_mcp.py          # MCP server for weather info
-│   ├── map_search_mcp.py       # Google Maps, HotPepper, Tabelog
-│   └── calendar_mcp.py         # Google Calendar/Todo (future)
-├── /graphs
-│   └── planner_graph.py        # LangGraph workflow (multi-agent)
-├── /tests
-│   └── test_spotify_mcp.py
--->
 
 ```txt
 langgraph-agentic-system-hub/
-├── README.md                  # このプロジェクトのドキュメント
-├── requirements.txt           # 依存ライブラリ一覧
-├── main.py                    # アプリのエントリーポイント
+├── README.md                  # Project documentation
+├── requirements.txt           # Dependency list
+├── main.py                    # Application entry point
 │
-├── agents/                    # 各エージェントのLangGraphノード処理
-│   ├── orchestrator.py        # タスクを適切なエージェントに振り分ける中核エージェント
-│   ├── music_agent.py         # Spotifyなど音楽系の処理を担うエージェント
-│   ├── event_agent.py         # 飲み会や週末スポット提案用のエージェント
-│   └── weather_agent.py       # 天気情報を取得するエージェント
+├── agents/                    # LangGraph node logic for each agent
+│   ├── orchestrator.py        # Central agent for task routing
+│   ├── music_agent.py         # Agent for music-related tasks (Spotify, etc.)
+│   ├── event_agent.py         # Agent for party/outing suggestions
+│   └── weather_agent.py       # Agent for weather information
 │
-├── tools/                     # 各種外部ツール（FastMCP）との連携サーバー
-│   ├── spotify_mcp.py         # Spotify楽曲検索用 MCP サーバー
-│   ├── weather_mcp.py         # 天気API取得用 MCP サーバー
-│   ├── map_search_mcp.py      # Google Maps / HotPepper / 食べログ連携（飲み会検索）
-│   └── calendar_mcp.py        # Google Calendar / TODO管理（今後追加予定）
+├── tools/                     # MCP servers for external tools (FastMCP)
+│   ├── spotify_mcp.py         # MCP server for Spotify search
+│   ├── weather_mcp.py         # MCP server for weather info
+│   ├── map_search_mcp.py      # Google Maps / HotPepper / Tabelog integration
+│   └── calendar_mcp.py        # Google Calendar / TODO management (planned)
 │
-├── graphs/                    # LangGraph フロー定義
-│   └── planner_graph.py       # マルチエージェント連携ワークフローの定義
+├── graphs/                    # LangGraph workflow definitions
+│   └── planner_graph.py       # Multi-agent workflow definition
 │
-├── memory/                    # LangChain Memory 機能（会話履歴保持）
-│   └── memory_config.py       # 記憶の保存/復元の定義（例：ChatMessageHistory）
+├── memory/                    # LangChain Memory (conversation history)
+│   └── memory_config.py       # Memory save/restore logic (e.g. ChatMessageHistory)
 │
-├── ui/                        # ユーザーインターフェース（例：Gradioなど）
-│   └── web_ui.py              # Webベースの対話インターフェース（開発中）
+├── ui/                        # User interface (e.g. Gradio)
+│   └── web_ui.py              # Web-based chat UI (in development)
 │
-├── tests/                     # ツールやエージェントの動作確認用テスト
-│   └── test_spotify_mcp.py    # Spotify MCP の動作テスト
+├── tests/                     # Tests for tools and agents
+│   └── test_spotify_mcp.py    # Spotify MCP test
 │
-└── docs/                      # アーキテクチャ設計資料やユースケースまとめ
-    └── architecture.png       # 全体構成図やフロー図など
+└── docs/                      # Architecture docs and use cases
+    └── architecture.png       # Diagrams, flowcharts, etc.
 ```
 
 ---
 
 ## 🔧 Requirements
+
 ```txt
 langchain
 langgraph
@@ -88,20 +69,10 @@ aiohttp
 gradio
 ```
 
-<!--
-## 🗂️ `requirements.txt` 例（ベース）
-```txt
-langgraph
-mcp
-openai
-spotipy
-python-dotenv
-fastapi
-uvicorn
-aiohttp
+You can install all dependencies at once with:
+```bash
+pip install -r requirements.txt
 ```
--->
-pip install -r requirements.txt で一括インストールできます。
 
 ## 🚀 Getting Started
 
@@ -112,7 +83,7 @@ git clone https://github.com/kenji/langgraph-agentic-system-hub.git
 cd langgraph-agentic-system-hub
 pip install -r requirements.txt
 ```
-<!-- ## 📦 How to Run -->
+
 ### 2. Run a tool MCP server
 ```bash
 python tools/spotify_mcp.py
@@ -125,60 +96,48 @@ python tools/weather_mcp.py
 python main.py
 ```
 
-### 4. Gradio UIを起動（今後追加）
+### 4. Launch the Gradio UI (coming soon)
 ```bash
 python ui/web_ui.py
 ```
 
 ## 🧩 Agentic Workflow Example
+
 ```txt
-User: 「週末に行けそうな場所を探して」
-→ Orchestrator: "PlannerAgent" へルーティング
-→ PlannerAgent: Web検索用MCPを利用
-→ Google Maps MCP + HotPepper MCP から情報取得
-→ 結果をLangGraph経由でユーザーに返す
+User: "Find a place to go this weekend"
+→ Orchestrator: routes to "PlannerAgent"
+→ PlannerAgent: uses web search MCP
+→ Gets info from Google Maps MCP + HotPepper MCP
+→ Returns results to user via LangGraph
 ```
 
 ## 🔮 Future Plans
+
 - 🧠 Memory integration with LangChain memory
 - 🔍 RAG (Retrieval-Augmented Generation) for dynamic search
-- 📆 Google Calendar連携で予定の自動調整
-- 📎 Notionへの自動まとめ機能
-- 🎤 YouTube音源分離ツールとの連携
-- 💬 Agent毎の専門プロンプト最適化
-- 🗺️ LangGraph SDK による視覚的ワークフロー生成
-
-<!--
-## 🔮 Future Extensions
-- 💬 LangChain Memory によるチャット履歴の保持
-- 🔍 RAG によるリアルタイムWeb検索（ニュース、週末スポットなど）
-- 🧠 Agent毎の専門プロンプト最適化
-- 🗺️ LangGraph SDK による視覚的ワークフロー生成
--->
+- 📆 Google Calendar integration for automatic scheduling
+- 📎 Notion auto-summary feature
+- 🎤 Integration with YouTube audio separation tools
+- 💬 Prompt optimization for each agent
+- 🗺️ Visual workflow generation with LangGraph SDK
 
 ## ✨ Example Use Cases
-| ユースケース       | 概要                                                                 |
-|--------------------|----------------------------------------------------------------------|
-| 🎵 音楽検索         | ユーザーの希望に応じて Spotify から楽曲検索・推薦を行います。              |
-| 🍺 飲み会番長       | 人数・日付・エリアに基づいて、良いお店を探して空席状況をチェックします。     |
-| 🌤 天気確認         | 現在地や指定されたエリアの天気情報を取得し、アドバイスを提供します。         |
-| 📆 タスク管理       | Google Calendar と連携して、予定の確認や ToDo リストの管理を行います。       |
-| 📍 お出かけ提案     | 人気の週末スポットやレビューを取得して、行き先をおすすめします。             |
+
+| Use Case         | Description                                                                 |
+|------------------|-----------------------------------------------------------------------------|
+| 🎵 Music Search  | Search and recommend songs from Spotify based on user requests.              |
+| 🍺 Party Finder  | Find good venues and check availability based on number, date, and area.     |
+| 🌤 Weather Info  | Get weather information for current or specified locations and provide advice.|
+| 📆 Task Manager  | Manage schedules and ToDo lists via Google Calendar integration.             |
+| 📍 Outing Ideas  | Suggest popular weekend spots and get reviews.                               |
 
 ## 👤 Author
+
 **Centaurus-Ken（[@ken-hori-2](https://github.com/ken-hori-2)）**
 
-LangGraph × MCP による Agentic AI システムの実験・開発を行う開発者。  
-普段は「こんなアプリがあったらいいな」という日常の願望を起点に、Agentic AI のコンセプト立案からマルチエージェント構成でのデモ開発・プレゼンまで幅広く担当。
-また、センシングデバイス上で動作するエッジ AI モデルの設計・構築、デモ開発にも従事しており、CI/CD パイプラインの構築やテスト自動化の経験も保有。
-今後はさらに多様なユースケース（音楽、天気、飲み会、予定管理など）に対応する Agentic AI Hub としての機能拡張を目指しています。
-
-<!--
-Author
-Centaurus-Ken（@ken-hori-2）
-LangGraph + MCP による Agentic AI 実験者。
-今後さらに多くのユースケースに対応予定です。
--->
+A developer experimenting with Agentic AI systems using LangGraph × MCP.  
+From ideation to demo development and presentation, focusing on real-world use cases like music, weather, party planning, and schedule management.  
+Also experienced in edge AI model design, demo development, and CI/CD pipeline automation.
 
 ## 📄 License
 
@@ -187,3 +146,48 @@ MIT License.
 Created by Centaurus-Ken for exploring next-gen LLM applications with modular tool orchestration.
 
 ---
+
+## Appendix: FastAPI + Uvicorn MCP Agent API Example
+
+This repository also includes a sample implementation of an MCP agent API using FastAPI and Uvicorn.
+
+### Directory Structure
+
+```
+src/uv_agent_api/
+  ├── uv_api_agent.py   # Agent core (LangGraph/LLM/Tool definitions)
+  ├── uv_api_main.py    # FastAPI server launcher
+  └── uv_api_client.py  # API client (for sending requests)
+```
+
+### 1. Start the Server
+
+```bash
+cd src/uv_agent_api
+uvicorn uv_api_main:app --reload --port 8001
+```
+
+### 2. Example: Using the Client
+
+In another terminal:
+
+```bash
+cd src/uv_agent_api
+python uv_api_client.py
+```
+
+- You can interact with the AI agent in a chat format.
+- Type `quit` or `exit` to end the session.
+
+### 3. API Endpoints
+
+- `POST /ask` : Send a question and get the AI agent's response
+- `GET /history` : Retrieve conversation history
+- `DELETE /history` : Clear conversation history
+
+### 4. Notes
+- `uv_api_agent.py` … Defines LangGraph/LLM/Tools/conversation memory and the agent core
+- `uv_api_main.py` … FastAPI server endpoint definitions
+- `uv_api_client.py` … Client for sending requests to the server
+
+If you need to use API keys or connect to external services, please refer to the comments and environment variable settings in each script. 

--- a/README_en_ja.md
+++ b/README_en_ja.md
@@ -1,0 +1,236 @@
+# LangGraph Agentic System Hub
+
+🧠 A modular and extensible framework for building multi-agent LLM applications using LangGraph and MCP tools.
+
+---
+
+## 🔥 Overview
+
+This project provides a **LangGraph-based agentic architecture** that integrates various tools (e.g. weather, Spotify, Google Maps, etc.) via **MCP (Modular Command Protocol)** to enable intelligent and dynamic task execution.
+
+It is designed to support:
+- 🗺️ Weekend spot planning with web search & map tools
+- 🍻 Party venue search with availability checks (HotPepper, Tabelog)
+- 🎧 Spotify music search & playback based on requests
+- ✅ Task management using calendar & to-do tools
+- 🎯 A unified orchestrator to route tasks to the best agent
+
+---
+
+## 🏗️ Project Structure
+<!--
+langgraph-agentic-system-hub/
+├── README.md
+├── requirements.txt
+├── main.py
+├── /agents
+│   ├── orchestrator.py         # Routes tasks to the appropriate agent
+│   ├── music_agent.py
+│   ├── event_agent.py
+│   └── weather_agent.py
+├── /tools
+│   ├── spotify_mcp.py          # MCP server for Spotify search
+│   ├── weather_mcp.py          # MCP server for weather info
+│   ├── map_search_mcp.py       # Google Maps, HotPepper, Tabelog
+│   └── calendar_mcp.py         # Google Calendar/Todo (future)
+├── /graphs
+│   └── planner_graph.py        # LangGraph workflow (multi-agent)
+├── /tests
+│   └── test_spotify_mcp.py
+-->
+
+```txt
+langgraph-agentic-system-hub/
+├── README.md                  # このプロジェクトのドキュメント
+├── requirements.txt           # 依存ライブラリ一覧
+├── main.py                    # アプリのエントリーポイント
+│
+├── agents/                    # 各エージェントのLangGraphノード処理
+│   ├── orchestrator.py        # タスクを適切なエージェントに振り分ける中核エージェント
+│   ├── music_agent.py         # Spotifyなど音楽系の処理を担うエージェント
+│   ├── event_agent.py         # 飲み会や週末スポット提案用のエージェント
+│   └── weather_agent.py       # 天気情報を取得するエージェント
+│
+├── tools/                     # 各種外部ツール（FastMCP）との連携サーバー
+│   ├── spotify_mcp.py         # Spotify楽曲検索用 MCP サーバー
+│   ├── weather_mcp.py         # 天気API取得用 MCP サーバー
+│   ├── map_search_mcp.py      # Google Maps / HotPepper / 食べログ連携（飲み会検索）
+│   └── calendar_mcp.py        # Google Calendar / TODO管理（今後追加予定）
+│
+├── graphs/                    # LangGraph フロー定義
+│   └── planner_graph.py       # マルチエージェント連携ワークフローの定義
+│
+├── memory/                    # LangChain Memory 機能（会話履歴保持）
+│   └── memory_config.py       # 記憶の保存/復元の定義（例：ChatMessageHistory）
+│
+├── ui/                        # ユーザーインターフェース（例：Gradioなど）
+│   └── web_ui.py              # Webベースの対話インターフェース（開発中）
+│
+├── tests/                     # ツールやエージェントの動作確認用テスト
+│   └── test_spotify_mcp.py    # Spotify MCP の動作テスト
+│
+└── docs/                      # アーキテクチャ設計資料やユースケースまとめ
+    └── architecture.png       # 全体構成図やフロー図など
+```
+
+---
+
+## 🔧 Requirements
+```txt
+langchain
+langgraph
+openai
+mcp
+fastapi
+spotipy
+python-dotenv
+aiohttp
+gradio
+```
+
+<!--
+## 🗂️ `requirements.txt` 例（ベース）
+```txt
+langgraph
+mcp
+openai
+spotipy
+python-dotenv
+fastapi
+uvicorn
+aiohttp
+```
+-->
+pip install -r requirements.txt で一括インストールできます。
+
+## 🚀 Getting Started
+
+### 1. Clone & install dependencies
+
+```bash
+git clone https://github.com/kenji/langgraph-agentic-system-hub.git
+cd langgraph-agentic-system-hub
+pip install -r requirements.txt
+```
+<!-- ## 📦 How to Run -->
+### 2. Run a tool MCP server
+```bash
+python tools/spotify_mcp.py
+# or
+python tools/weather_mcp.py
+```
+
+### 3. Run the LangGraph agent
+```bash
+python main.py
+```
+
+### 4. Gradio UIを起動（今後追加）
+```bash
+python ui/web_ui.py
+```
+
+## 🧩 Agentic Workflow Example
+```txt
+User: 「週末に行けそうな場所を探して」
+→ Orchestrator: "PlannerAgent" へルーティング
+→ PlannerAgent: Web検索用MCPを利用
+→ Google Maps MCP + HotPepper MCP から情報取得
+→ 結果をLangGraph経由でユーザーに返す
+```
+
+## 🔮 Future Plans
+- 🧠 Memory integration with LangChain memory
+- 🔍 RAG (Retrieval-Augmented Generation) for dynamic search
+- 📆 Google Calendar連携で予定の自動調整
+- 📎 Notionへの自動まとめ機能
+- 🎤 YouTube音源分離ツールとの連携
+- 💬 Agent毎の専門プロンプト最適化
+- 🗺️ LangGraph SDK による視覚的ワークフロー生成
+
+<!--
+## 🔮 Future Extensions
+- 💬 LangChain Memory によるチャット履歴の保持
+- 🔍 RAG によるリアルタイムWeb検索（ニュース、週末スポットなど）
+- 🧠 Agent毎の専門プロンプト最適化
+- 🗺️ LangGraph SDK による視覚的ワークフロー生成
+-->
+
+## ✨ Example Use Cases
+| ユースケース       | 概要                                                                 |
+|--------------------|----------------------------------------------------------------------|
+| 🎵 音楽検索         | ユーザーの希望に応じて Spotify から楽曲検索・推薦を行います。              |
+| 🍺 飲み会番長       | 人数・日付・エリアに基づいて、良いお店を探して空席状況をチェックします。     |
+| 🌤 天気確認         | 現在地や指定されたエリアの天気情報を取得し、アドバイスを提供します。         |
+| 📆 タスク管理       | Google Calendar と連携して、予定の確認や ToDo リストの管理を行います。       |
+| 📍 お出かけ提案     | 人気の週末スポットやレビューを取得して、行き先をおすすめします。             |
+
+## 👤 Author
+**Centaurus-Ken（[@ken-hori-2](https://github.com/ken-hori-2)）**
+
+LangGraph × MCP による Agentic AI システムの実験・開発を行う開発者。  
+普段は「こんなアプリがあったらいいな」という日常の願望を起点に、Agentic AI のコンセプト立案からマルチエージェント構成でのデモ開発・プレゼンまで幅広く担当。
+また、センシングデバイス上で動作するエッジ AI モデルの設計・構築、デモ開発にも従事しており、CI/CD パイプラインの構築やテスト自動化の経験も保有。
+今後はさらに多様なユースケース（音楽、天気、飲み会、予定管理など）に対応する Agentic AI Hub としての機能拡張を目指しています。
+
+<!--
+Author
+Centaurus-Ken（@ken-hori-2）
+LangGraph + MCP による Agentic AI 実験者。
+今後さらに多くのユースケースに対応予定です。
+-->
+
+## 📄 License
+
+MIT License.
+
+Created by Centaurus-Ken for exploring next-gen LLM applications with modular tool orchestration.
+
+---
+
+## Appendix: FastAPI + Uvicorn MCP Agent API Example
+
+このリポジトリには、FastAPIとUvicornを用いたMCPエージェントAPIのサンプル実装も含まれています。
+
+### ディレクトリ構成
+
+```
+src/uv_agent_api/
+  ├── uv_api_agent.py   # Agent本体（LangGraph/LLM/Tool定義）
+  ├── uv_api_main.py    # FastAPIサーバー起動用
+  └── uv_api_client.py  # APIクライアント（リクエスト送信用）
+```
+
+### 1. サーバーの起動
+
+```bash
+cd src/uv_agent_api
+uvicorn uv_api_main:app --reload --port 8001
+```
+
+### 2. クライアントからの利用例
+
+別ターミナルで：
+
+```bash
+cd src/uv_agent_api
+python uv_api_client.py
+```
+
+- 対話形式でAIエージェントに質問できます。
+- `quit` または `exit` で終了します。
+
+### 3. エンドポイント一覧
+
+- `POST /ask` : 質問を送信し、AIエージェントの応答を取得
+- `GET /history` : 会話履歴を取得
+- `DELETE /history` : 会話履歴をクリア
+
+### 4. 補足
+- `uv_api_agent.py` … LangGraph/LLM/Tool/会話履歴の定義とエージェント本体
+- `uv_api_main.py` … FastAPIサーバーのエンドポイント定義
+- `uv_api_client.py` … サーバーへリクエストを送るクライアント
+
+APIキーや外部サービス連携が必要な場合は、各スクリプト内のコメントや環境変数設定を参照してください。
+
+---

--- a/src/uv_agent_api/uv_api_agent.py
+++ b/src/uv_agent_api/uv_api_agent.py
@@ -1,0 +1,103 @@
+# agent.py
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from typing import Dict, Any, TypedDict, List
+from langchain_google_community import GoogleSearchAPIWrapper
+from langchain.agents import Tool
+from langgraph.prebuilt import create_react_agent
+import os
+from langchain.memory import ConversationBufferMemory
+from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+# メモリーの初期化
+memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+
+class AgentState(TypedDict):
+    input: str
+    result: str
+    chat_history: List[Any]
+
+def create_tools() -> List[Tool]:
+    # Google検索ツールの作成
+    def search_google(query: str) -> str:
+        try:
+            search = GoogleSearchAPIWrapper()
+            return search.run(query)
+        except Exception as e:
+            return f"検索中にエラーが発生しました: {str(e)}"
+
+    google_search_tool = Tool.from_function(
+        func=search_google,
+        name="Google_Search",
+        description="インターネットで情報を検索します。"
+    )
+
+    return [google_search_tool]
+
+def agent_node(state: AgentState) -> AgentState:
+    question = state["input"]
+    chat_history = state.get("chat_history", [])
+    
+    try:
+        # LLMの初期化
+        llm = ChatOpenAI(temperature=0.7)
+        
+        # ツールの準備
+        tools = create_tools()
+        
+        # ReActエージェントの作成
+        agent = create_react_agent(llm, tools)
+        
+        # 会話履歴を含めたメッセージの作成
+        messages = chat_history + [HumanMessage(content=question)]
+        
+        # エージェントの実行
+        result = agent.invoke(
+            {
+                "messages": messages
+                # "messages": [
+                #     (
+                #         "human",
+                #         (
+                #             "Execute the following task and provide a detailed response.\n\n"
+                #             f"Task: {question}\n\n"
+                #             "Requirements:\n"
+                #             "1. Use the provided tools as needed.\n"
+                #             "2. Execute thoroughly and comprehensively.\n"
+                #             "3. Provide as specific facts and data as possible.\n"
+                #             "4. Summarize the findings clearly.\n"
+                #         ),
+                #     )
+                # ]
+            }
+        )
+
+        # 会話履歴を更新
+        memory.save_context(
+            {"input": question},
+            {"output": result["messages"][-1].content}
+        )
+
+        return {
+            "input": question,
+            "result": result["messages"][-1].content,
+            "chat_history": memory.chat_memory.messages
+        }
+    except Exception as e:
+        error_message = f"エージェントの実行中にエラーが発生しました: {str(e)}"
+        print(error_message)  # サーバー側のログに出力
+        return {
+            "input": question,
+            "result": error_message,
+            "chat_history": chat_history
+        }
+
+# LangGraph構築
+builder = StateGraph(AgentState)
+builder.add_node("agent", agent_node)
+builder.set_entry_point("agent")
+builder.set_finish_point("agent")
+
+# 実行グラフ作成
+graph = builder.compile()

--- a/src/uv_agent_api/uv_api_client.py
+++ b/src/uv_agent_api/uv_api_client.py
@@ -1,0 +1,55 @@
+import requests
+import json
+from typing import Optional
+
+class AgentClient:
+    def __init__(self, base_url: str = "http://127.0.0.1:8001"):
+        self.base_url = base_url
+
+    def ask(self, question: str) -> Optional[str]:
+        """
+        AIエージェントに質問を送信します。
+
+        Args:
+            question (str): 質問内容
+
+        Returns:
+            Optional[str]: AIからの応答。エラーの場合はNone
+        """
+        try:
+            response = requests.post(
+                f"{self.base_url}/ask",
+                json={"input": question},
+                headers={"Content-Type": "application/json"}
+            )
+            response.raise_for_status()
+            return response.json()["response"]
+        except requests.exceptions.RequestException as e:
+            print(f"エラーが発生しました: {e}")
+            return None
+
+def main():
+    client = AgentClient()
+    
+    print("AIエージェントとの対話を開始します。終了するには 'quit' または 'exit' と入力してください。")
+    print("-" * 50)
+    
+    while True:
+        question = input("\n質問を入力してください: ").strip()
+        
+        if question.lower() in ["quit", "exit"]:
+            print("対話を終了します。")
+            break
+            
+        if not question:
+            print("質問を入力してください。")
+            continue
+            
+        response = client.ask(question)
+        if response:
+            print("\nAIの応答:")
+            print(response)
+        print("-" * 50)
+
+if __name__ == "__main__":
+    main() 

--- a/src/uv_agent_api/uv_api_main.py
+++ b/src/uv_agent_api/uv_api_main.py
@@ -1,0 +1,60 @@
+# main.py
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from uv_api_agent import graph, memory
+from typing import List, Dict
+
+app = FastAPI(
+    title="AI Agent API",
+    description="LangGraphを使用したAIエージェントのAPI",
+    version="1.0.0"
+)
+
+# class Request(BaseModel):
+#     input: str
+
+#     class Config:
+#         schema_extra = {
+#             "example": {
+#                 "input": "こんにちは、元気ですか？"
+#             }
+#         }
+class Query(BaseModel):
+    input: str
+
+# 会話履歴を保持するためのグローバル変数
+current_state = {
+    "input": "",
+    "result": "",
+    "chat_history": []
+}
+
+@app.post("/ask", response_model=dict)
+async def ask_endpoint(query: Query):
+    try:
+        # 現在の状態を更新
+        current_state["input"] = query.input
+        
+        # エージェントを呼び出し
+        result = graph.invoke(current_state)
+        
+        # 状態を更新
+        current_state.update(result)
+        
+        return {"response": result["result"]}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/")
+async def root():
+    return {"message": "AI Agent API へようこそ！"}
+
+@app.get("/history")
+async def get_history():
+    return {"history": memory.chat_memory.messages}
+
+@app.delete("/history")
+async def clear_history():
+    memory.chat_memory.clear()
+    current_state["chat_history"] = []
+    return {"message": "会話履歴をクリアしました"}


### PR DESCRIPTION
## Overview

This pull request adds the following features:

- An English version of the README (`README_en.md`) for international users and contributors.
- A sample implementation of an agent API using FastAPI and Uvicorn, located in `src/uv_agent_api/`.
    - `uv_api_agent.py`: The agent logic using LangGraph and LLM tools.
    - `uv_api_main.py`: FastAPI server to expose the agent as an API.
    - `uv_api_client.py`: Example client for sending requests to the API.

## Details

- The English README provides a full translation of the original documentation, including project overview, structure, setup instructions, and usage examples.
- The FastAPI+Uvicorn agent API sample demonstrates how to run the agent as a web service and interact with it via HTTP endpoints.
- The API supports endpoints for asking questions, retrieving conversation history, and clearing history.

## Motivation

- Improve accessibility for non-Japanese speakers.
- Provide a practical example of deploying the agent as a web API for integration with other systems.

## How to Use

1. See the `README_en.md` for full instructions in English.
2. To try the API sample:
    - Start the server:  
      `cd src/uv_agent_api && uvicorn uv_api_main:app --reload --port 8001`
    - Run the client:  
      `cd src/uv_agent_api && python uv_api_client.py`